### PR TITLE
use emoticons in unicode example

### DIFF
--- a/gems/unicode.md
+++ b/gems/unicode.md
@@ -90,9 +90,9 @@ import std.stdio;
 
 void main()
 {
-    string utf8 = "å ø ∑ œ";
-    wstring utf16 = "å ø ∑ œ";
-    dstring utf32 = "å ø ∑ œ";
+    string utf8 = "å ø ∑ 😦";
+    wstring utf16 = "å ø ∑ 😦";
+    dstring utf32 = "å ø ∑ 😦";
 
     writeln("utf8 length: ", utf8.length);
     writeln("utf16 length: ", utf16.length);


### PR DESCRIPTION
I know some don't like emoijs in Unicode, but they are part of the >= 2^16 blocks, so they might be a good example for utf32?

https://en.wikipedia.org/wiki/Emoticons_(Unicode_block)


Before:

```
utf8 length: 12
utf16 length: 7
utf32 length: 7
```

After:

```
utf8 length: 14
utf16 length: 8
utf32 length: 7
```