### PR TITLE
Use Markdown table syntax for the types table

### DIFF
--- a/basics/basic-types.md
+++ b/basics/basic-types.md
@@ -21,7 +21,7 @@ is compiled for 32-bit or 64-bit systems.
 |---------|--------------------------------------------------
 |`float`  | 32-bit
 |`double` | 64-bit
-|`real`   | depending on platform, 80-bit on Intel x86 32-bit
+|`real`   | >= 64-bit (depending on platform - generally 64-bit, but 80-bit on Intel x86 32-bit)
 
 The prefix `u` denotes *unsigned* types. `char` translates to
 UTF-8 characters, `wchar` is used in UTF-16 strings and `dchar`

--- a/basics/basic-types.md
+++ b/basics/basic-types.md
@@ -21,7 +21,7 @@ is compiled for 32-bit or 64-bit systems.
 |---------|--------------------------------------------------
 |`float`  | 32-bit
 |`double` | 64-bit
-|`real`   | >= 64-bit (depending on platform - generally 64-bit, but 80-bit on Intel x86 32-bit)
+|`real`   | >= 64-bit (generally 64-bit, but 80-bit on Intel x86 32-bit)
 
 The prefix `u` denotes *unsigned* types. `char` translates to
 UTF-8 characters, `wchar` is used in UTF-16 strings and `dchar`

--- a/basics/basic-types.md
+++ b/basics/basic-types.md
@@ -7,21 +7,21 @@ precision. There is no difference
 between the size of an integer regardless whether the application
 is compiled for 32-bit or 64-bit systems.
 
-<table class="table table-hover">
-<tr><td width="250px"><code class="prettyprint">bool</code></td> <td>8-bit</td></tr>
-<tr><td><code class="prettyprint">byte, ubyte, char</code></td> <td>8-bit</td></tr>
-<tr><td><code class="prettyprint">short, ushort, wchar</code></td> <td>16-bit</td></tr>
-<tr><td><code class="prettyprint">int, uint, dchar</code></td> <td>32-bit</td></tr>
-<tr><td><code class="prettyprint">long, ulong</code></td> <td>64-bit</td></tr>
-</table>
+| type                          | size
+|-------------------------------|------------
+|`bool`                         | 8-bit
+|`bool`, `ubyte`, `char`        | 8-bit
+|`short`, `ushort`, `wchar`     | 16-bit
+|`int`, `uint`, `dchar`         | 32-bit
+|`long`, `ulong`                | 32-bit
 
 #### Floating point types:
 
-<table class="table table-hover">
-<tr><td width="250px"><code class="prettyprint">float</code></td> <td>32-bit</td></tr>
-<tr><td><code class="prettyprint">double</code></td> <td>64-bit</td></tr>
-<tr><td><code class="prettyprint">real</code></td> <td>depending on platform, 80-bit on Intel x86 32-bit</td></tr>
-</table>
+| type    | size
+|---------|--------------------------------------------------
+|`float`  | 32-bit
+|`double` | 64-bit
+|`real`   | depending on platform, 80-bit on Intel x86 32-bit
 
 The prefix `u` denotes *unsigned* types. `char` translates to
 UTF-8 characters, `wchar` is used in UTF-16 strings and `dchar`


### PR DESCRIPTION
If https://github.com/stonemaster/dlang-tour/pull/471 is enabled, we can think about the best way to convert the HTML tables to markdown:
- AFAICT the Vibe.d Markdown parser requires a header (we could fork it?)
- Tweaking the CSS (see the screenshots below, we could also drop the dlang.org CSS here and use the a more modern one like e.g. here on GitHub?)

without `table` CSS class:

![image](https://cloud.githubusercontent.com/assets/4370550/17986222/f80c889c-6b19-11e6-9d58-c042d3507f7e.png)

with `table` CSS class:

![image](https://cloud.githubusercontent.com/assets/4370550/17986265/172dfcb0-6b1a-11e6-93c2-3175982d3a0e.png)

currently

![image](https://cloud.githubusercontent.com/assets/4370550/17986279/27f9c68c-6b1a-11e6-8b76-3a0e100c1348.png)
