### PR TITLE
Fix wrong selective import explanation

### DIFF
--- a/basics/imports-and-modules.md
+++ b/basics/imports-and-modules.md
@@ -9,10 +9,13 @@ is located under the **package** `std`
 and those modules are referenced through `import std.MODULE`.
 
 The `import` statement can also be used to selectively
-import certain symbols of a module. This improves
-the already short compile time of D source code.
+import certain symbols of a module:
 
     import std.stdio: writeln, writefln;
+
+Selective imports can be used to improve the readability by making
+it obvious where a symbol comes from and also as a way to
+prevent clashing of symbols with the same name from different modules.
 
 An `import` statement does not need to appear at the top a source file.
 It can also be used locally within functions or any other scope.


### PR DESCRIPTION
Using selective imports in fact has zero effect on
compilation times as imported module still has to be
fully semantically analyzed.