### PR TITLE
Minor ranges example improvements

### DIFF
--- a/basics/ranges.md
+++ b/basics/ranges.md
@@ -47,7 +47,7 @@ import std.stdio;
 
 struct FibonacciRange
 {
-    @property empty() const
+    bool empty() const @property 
     {
         // So when does the Fibonacci sequence
         // end?!
@@ -57,7 +57,7 @@ struct FibonacciRange
     {
     }
 
-    int front()
+    int front() @property
     {
     }
 }


### PR DESCRIPTION
Removes the reliance on implicit `auto` return type
deduction from using `@property` to not confuse newcomers
and moved `@property` to right function side where method
atributes are normally written.

Also `front` is supposed to be @property compatible too: https://dlang.org/phobos/std_range_primitives.html#isInputRange