### PR TITLE
Add a simple language overview

### DIFF
--- a/welcome/index.yml
+++ b/welcome/index.yml
@@ -1,6 +1,7 @@
 title: Welcome
 ordering:
 - welcome-to-d
+- languages
 - install-d-locally
 - run-d-program-locally
 - links-documentation

--- a/welcome/languages.md
+++ b/welcome/languages.md
@@ -1,0 +1,20 @@
+# Read in a your language
+
+The Dlang Tour is available in multiple languages:
+
+- [German - Deutsch](https://tour.dlang.org/de/welcome/welcome-to-d)
+- [Italian - Italiano](https://tour.dlang.org/de/welcome/welcome-to-d)
+- [Japanese - 日本語](https://tour.dlang.org/ja/welcome/welcome-to-d)
+- [Russian - Pусский](https://tour.dlang.org/ru/welcome/welcome-to-d)
+- [Spanish - Español](https://tour.dlang.org/es/welcome/welcome-to-d)
+- [Swedish - Svenska](https://tour.dlang.org/sv/welcome/welcome-to-d)
+- [Turkish - Türkçe](https://tour.dlang.org/tr/welcome/welcome-to-d)
+- [Ukrainian - Українська](https://tour.dlang.org/uk/welcome/welcome-to-d)
+
+For English, just click on "Next" or use the right arrow key.
+
+## Your language isn't listed here?
+
+You can find in-work [translations here](https://github.com/dlang-tour),
+or ping us on [GitHub](https://github.com/stonemaster/dlang-tour/issues/new) to start
+a new translation repository.

--- a/welcome/languages.md
+++ b/welcome/languages.md
@@ -1,4 +1,4 @@
-# Read in a your language
+# Read in your language
 
 The Dlang Tour is available in multiple languages:
 
@@ -15,6 +15,6 @@ For English, just click on "Next" or use the right arrow key.
 
 ## Your language isn't listed here?
 
-You can find in-work [translations here](https://github.com/dlang-tour),
+You can find translations in the works [here](https://github.com/dlang-tour),
 or ping us on [GitHub](https://github.com/stonemaster/dlang-tour/issues/new) to start
 a new translation repository.


### PR DESCRIPTION
While not being a perfect solution, I think for now we could list the available languages in the simplest possible way, s.t. people can find them and we maybe even attract more volunteer how help with the translation.
In any case the russian, japanese and ukrainian translation are quite far ;-)