### PR TITLE
Add instructions on how to run the tour locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,20 @@ Just click on "edit" and send us a pull request.
 If you want to discuss an idea for a change first,
 don't hesitate to open an [issue](https://github.com/dlang-tour/english/issues).
 
-You might also be looking for the [base repository](https://github.com/dlang-tour)
+You might also be looking for the [base repository](https://github.com/stonemaster/dlang-tour)
 that hosts the content.
+
+Run locally
+-----------
+
+You will need to fetch the [base repository](https://github.com/stonemaster/dlang-tour) via DUB once:
+
+```sh
+dub fetch dlang-tour
+```
+
+Now you can execute `dlang-tour` in the root directory of this repository:
+
+```sh
+dub run dlang-tour -- --lang-dir .
+```


### PR DESCRIPTION
Adds the instructions to preview the tour locally.

(Note that I had to release 1.0.3 of the base repo for the DMD 2.072 fixes to be included) 