### PR TITLE
Let Travis run in user-mode (i.e. non-sudo)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: d
 d:
   - dmd
@@ -6,9 +5,10 @@ d:
 branches:
   only:
     - master
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libevent-dev
+addons:
+  apt:
+    packages:
+    - libevent-dev
 script:
   - git clone https://github.com/stonemaster/dlang-tour ../tour
   - mkdir -p ../tour/public/content/lang


### PR DESCRIPTION
`Non-sudo` builds are containers on Travis and thus boot faster (see also https://docs.travis-ci.com/user/ci-environment/)