### PR TITLE
Correct grammar - caught rather than catched

### DIFF
--- a/basics/exceptions.md
+++ b/basics/exceptions.md
@@ -1,7 +1,7 @@
 # Exceptions
 
 This guide is only about User-`Exceptions` - System-`Errors` are usually fatal
-and should __never__ be catched.
+and should __never__ be caught.
 
 ### Catching Exception
 


### PR DESCRIPTION
"System errors are fatal and should never be catched" 

The grammar in this sentence is incorrect, the proper verb is 'caught'