### PR TITLE
Correct animal noises

### DIFF
--- a/basics/interfaces.md
+++ b/basics/interfaces.md
@@ -80,7 +80,7 @@ interface Animal {
 
 class Dog: Animal {
     override void makeNoise() {
-        writeln("Bark!");
+        writeln("Woof!");
     }
 }
 

--- a/basics/templates.md
+++ b/basics/templates.md
@@ -76,7 +76,7 @@ class Animal(string noise) {
     }
 }
 
-class Dog: Animal!("Bark") {
+class Dog: Animal!("Woof") {
 }
 
 class Cat: Animal!("Meeoauw") {


### PR DESCRIPTION
Dogs do not say "bark", they say "woof" -- "bark" is the verb but "woof" is the name of the sound. :-)
![Google](http://i.imgur.com/ASA3Ms2.png)