### PR TITLE
Add WIP remark to language page

### DIFF
--- a/welcome/languages.md
+++ b/welcome/languages.md
@@ -1,15 +1,15 @@
-# Read in a your language
+# Read in your language
 
 The Dlang Tour is available in multiple languages:
 
-- [Brazilian Portuguese - Português Brasileiro](https://tour.dlang.org/tour/pt/welcome/welcome-to-d)
-- [German - Deutsch](https://tour.dlang.org/tour/de/welcome/welcome-to-d)
-- [Italian - Italiano](https://tour.dlang.org/tour/it/welcome/welcome-to-d)
+- [Brazilian Portuguese - Português Brasileiro](https://tour.dlang.org/tour/pt/welcome/welcome-to-d) (partially, WIP)
+- [German - Deutsch](https://tour.dlang.org/tour/de/welcome/welcome-to-d) (partially, WIP)
+- [Italian - Italiano](https://tour.dlang.org/tour/it/welcome/welcome-to-d) (partially, WIP)
 - [Japanese - 日本語](https://tour.dlang.org/tour/ja/welcome/welcome-to-d)
 - [Russian - Pусский](https://tour.dlang.org/tour/ru/welcome/welcome-to-d)
-- [Spanish - Español](https://tour.dlang.org/tour/es/welcome/welcome-to-d)
-- [Swedish - Svenska](https://tour.dlang.org/tour/sv/welcome/welcome-to-d)
-- [Turkish - Türkçe](https://tour.dlang.org/tour/tr/welcome/welcome-to-d)
+- [Spanish - Español](https://tour.dlang.org/tour/es/welcome/welcome-to-d) (partially, WIP)
+- [Swedish - Svenska](https://tour.dlang.org/tour/sv/welcome/welcome-to-d) (partially, WIP)
+- [Turkish - Türkçe](https://tour.dlang.org/tour/tr/welcome/welcome-to-d) (partially, WIP)
 - [Ukrainian - Українська](https://tour.dlang.org/tour/uk/welcome/welcome-to-d)
 
 For English, just click on "Next" or use the right arrow key.


### PR DESCRIPTION
At DConf I was reminded that newcomers get lost in a translation quite easily if it's incomplete. Ideally we should show this at the end of a translation (e.g. a new page: "This translation ends here - you can help to improve it"). As the latter is a bit more difficult, here's a rather easy fix.

I didn't want to use WIP everywhere, so I considered languages where the basic are fully translated as not partially translated.