### PR TITLE
DStyle: remove whitespace around function arguments

### DIFF
--- a/basics/type-qualifiers.md
+++ b/basics/type-qualifiers.md
@@ -33,7 +33,7 @@ scope, but someone else might modify it from a different context. It is common
 for APIs to accept `const` arguments to ensure they don't modify the input as
 that allows same function to process both mutable and immutable data.
 
-    void foo ( const char[] s )
+    void foo(const char[] s)
     {
         // if not commented out, next line will
         // result in error (can't modify const):


### PR DESCRIPTION
I think the later is by far the more common style (and the one officially used in Phobos).