### PR TITLE
Link to std.algorithm.iteration.splitter

### DIFF
--- a/basics/alias-strings.md
+++ b/basics/alias-strings.md
@@ -13,7 +13,8 @@ introduction: welcome UTF-8 `string`!
 
 Due to their immutablility, `string`s can be shared perfectly among
 different threads. As `string` is a slice, parts can be taken out of it without
-allocating memory. The standard function `std.algorithm.splitter`
+allocating memory. The standard function
+[`std.algorithm.splitter`](https://dlang.org/phobos/std_algorithm_iteration.html#.splitter)
 for example, splits a string by newline without any memory allocations.
 
 Besides the UTF-8 `string`, there are two more types:


### PR DESCRIPTION
To be pedantically correct, it would be `std.algorithm.iteration.splitter`.
However, I am not sure whether the correctness is worth the additional load onto the reader.