### PR TITLE
Remove imports from std.array

### DIFF
--- a/basics/loops.md
+++ b/basics/loops.md
@@ -74,14 +74,9 @@ the elements of an array.
 */
 double average(int[] array)
 {
-    // The property .empty for arrays isn't
-    // native in D but has to be made accessible
-    // by importing the function from std.array
-    import std.array : empty, front;
-
+    immutable length = array.length;
     double accumulator = 0.0;
-    auto length = array.length;
-    while (!array.empty)
+    while (array.length)
     {
         // this could be also done with .front
         // with import std.array : front;

--- a/basics/loops.md
+++ b/basics/loops.md
@@ -74,7 +74,7 @@ the elements of an array.
 */
 double average(int[] array)
 {
-    immutable length = array.length;
+    immutable initialLength = array.length;
     double accumulator = 0.0;
     while (array.length)
     {
@@ -84,7 +84,7 @@ double average(int[] array)
         array = array[1 .. $];
     }
 
-    return accumulator / length;
+    return accumulator / initialLength;
 }
 
 void main()


### PR DESCRIPTION
The range imports are confusing and they should be from `std.range.primitives` anyways