### PR TITLE
Add a editorconfig + checks for {trailing whitespace,tabs}

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.md]
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ addons:
     packages:
     - libevent-dev
 script:
+  - echo "Check for trailing whitespace"
+  - grep -nr --include \*.md '\s$' . ; test $? -eq 1
+  - echo "Check for tabs"
+  - grep -nrP --include \*.md '\t' . ; test $? -eq 1
   - git clone https://github.com/dlang-tour/core ../tour
   - mkdir -p ../tour/public/content/lang
   - mv * ../tour/public/content/lang

--- a/basics/exceptions.md
+++ b/basics/exceptions.md
@@ -128,13 +128,13 @@ void main()
     }
     catch (FileException e)
     {
-		writeln("Message:\n", e.msg);
-		writeln("File: ", e.file);
-		writeln("Line: ", e.line);
-		writeln("Stack trace:\n", e.info);
+        writeln("Message:\n", e.msg);
+        writeln("File: ", e.file);
+        writeln("Line: ", e.line);
+        writeln("Stack trace:\n", e.info);
 
-		// Default formatting could be used too
-		// writeln(e);
+        // Default formatting could be used too
+        // writeln(e);
     }
 }
 ```

--- a/basics/interfaces.md
+++ b/basics/interfaces.md
@@ -66,8 +66,8 @@ interface Animal {
     NVI pattern. Uses makeNoise internally
     to customize behaviour inheriting
     classes.
-    
-    Params: 
+
+    Params:
         n =  number of repetitions
     */
     final void multipleNoise(int n) {

--- a/basics/slices.md
+++ b/basics/slices.md
@@ -64,7 +64,7 @@ void main()
     writeln("First element: ", test[0]);
     writeln("Last element: ", test[$ - 1]);
     writeln("Exclude the first two elements: ",
-    	test[2 .. $]);
+        test[2 .. $]);
 
     writeln("Slices are views on the memory:");
     auto test2 = test;

--- a/gems/attributes.md
+++ b/gems/attributes.md
@@ -15,7 +15,7 @@ a normal member to the outside world:
         @property bar() { return 10; }
         @property bar(int x) { writeln(x); }
     }
-    
+
     Foo foo;
     writeln(foo.bar); // actually calls foo.bar()
     foo.bar = 10; // calls foo.bar(10);
@@ -40,7 +40,7 @@ Any function or type in D can be attributed with user-defined
 types:
 
     struct Bar { this(int x) {} }
-    
+
     struct Foo {
       @("Hello") {
           @Bar(10) void foo() {

--- a/gems/bit-manipulation.md
+++ b/gems/bit-manipulation.md
@@ -110,14 +110,14 @@ void main()
     // 4 bytes (int) per variable
     writeln(Vector.sizeof);
 
-	struct BadVector
-	{
-		bool a;
-		int x, y, z;
-		bool b;
-	}
-	// due to padding,
-	// 4 bytes are used for each field
-	writeln(BadVector.sizeof);
+    struct BadVector
+    {
+        bool a;
+        int x, y, z;
+        bool b;
+    }
+    // due to padding,
+    // 4 bytes are used for each field
+    writeln(BadVector.sizeof);
 }
 ```

--- a/gems/compile-time-function-evaluation-ctfe.md
+++ b/gems/compile-time-function-evaluation-ctfe.md
@@ -58,8 +58,8 @@ using Newton's approximation scheme.
 
 Params:
     x = number to be squared
-    
-Returns: square root of x 
+
+Returns: square root of x
 */
 auto sqrt(T)(T x) {
     // our epsilon when to stop the

--- a/gems/contract-programming.md
+++ b/gems/contract-programming.md
@@ -98,10 +98,10 @@ struct Date {
     /**
     Serializes Date object from a
     YYYY-MM-DD string.
-    
+
     Params:
         date = string to be serialized
-        
+
     Returns: Date object.
     */
     void fromString(string date)

--- a/gems/functional-programming.md
+++ b/gems/functional-programming.md
@@ -82,13 +82,13 @@ void main()
     void test()
     {
         writefln(".uintLength() = %s ",
-        	   fastBigPow(5, 10000).uintLength);
+               fastBigPow(5, 10000).uintLength);
     }
 
     foreach (i; 0 .. 10)
         benchmark!test(1)[0]
-        	.to!("msecs", double)
-        	.reverseArgs!writefln
-        		(" took: %.2f miliseconds");
+            .to!("msecs", double)
+            .reverseArgs!writefln
+                (" took: %.2f miliseconds");
 }
 ```

--- a/gems/template-meta-programming.md
+++ b/gems/template-meta-programming.md
@@ -102,7 +102,7 @@ private:
     /*
     Generator for getter and setter because
     we really hate boiler plate!
-    
+
     var -> T getVAR() and void setVAR(T)
     */
     mixin template GetterSetter(string var) {

--- a/gems/uniform-function-call-syntax-ufcs.md
+++ b/gems/uniform-function-call-syntax-ufcs.md
@@ -60,6 +60,6 @@ void main()
 
     // Traditional style:
     writeln(filter!(a => a % 2 == 0)
-    			   (iota(10)));
+                   (iota(10)));
 }
 ```

--- a/multithreading/message-passing.md
+++ b/multithreading/message-passing.md
@@ -24,7 +24,7 @@ additional parameters to that function as arguments.
         receive(
           (int i) { writeln("An ", i, " was sent!"); }
         );
-        
+
         send(parentTid, "Done");
     }
 

--- a/vibed/deploy-on-heroku.md
+++ b/vibed/deploy-on-heroku.md
@@ -73,8 +73,8 @@ Notice the remote endpoint is added to the git config:
 
 ```
 $ git remote -v
-heroku	https://git.heroku.com/rocky-hamlet-67506.git (fetch)
-heroku	https://git.heroku.com/rocky-hamlet-67506.git (push)
+heroku    https://git.heroku.com/rocky-hamlet-67506.git (fetch)
+heroku    https://git.heroku.com/rocky-hamlet-67506.git (push)
 ```
 
 ### Adding the buildpack

--- a/welcome/welcome-to-d.md
+++ b/welcome/welcome-to-d.md
@@ -55,7 +55,7 @@ void main()
 {
     // Let's get going!
     writeln("Hello World!");
-    
+
     // An example for experienced programmers:
     // Take three arrays, and without allocating
     // any new memory, sort across all the


### PR DESCRIPTION
This was always the standard: https://github.com/dlang-tour/core/blob/master/.editorconfig, but the `.editorconfig` didn't get copied over on the split.