### PR TITLE
prevent confusion with the debug switch

### DIFF
--- a/gems/contract-programming.md
+++ b/gems/contract-programming.md
@@ -3,8 +3,8 @@
 Contract programming in D includes a set of language constructs that allow increasing the code quality 
 by implementing sanity checks that make sure that the code base behaves as intended. 
 Contracts are compiled and exectued when the software is build for testing or debugging. 
-In release builds (**-release** for DMD) they are completly skipped by the compiler,
-therefore they shouldn't be used to validate user input or as an alternative exception system.
+In release builds (enabled by the **-release** switch for DMD) they are completly omitted by the compiler,
+therefore they shouldn't be used to validate user input or as an alternative to using exceptions.
 
 ### `assert`
 

--- a/gems/contract-programming.md
+++ b/gems/contract-programming.md
@@ -1,9 +1,9 @@
 # Contract programming
 
-Contract programming in D includes a set of language constructs that allow increasing the code quality 
-by implementing sanity checks that make sure that the code base behaves as intended. 
-Contracts are compiled and exectued when the software is build for testing or debugging. 
-In release builds (enabled by the **-release** switch for DMD) they are completly omitted by the compiler,
+Contract programming in D includes a set of language constructs that allow increasing the code quality
+by implementing sanity checks that make sure that the code base behaves as intended.
+Contracts are compiled and executed when the software is build for testing or debugging.
+In release builds (enabled by the **-release** switch for DMD) they are completely omitted by the compiler,
 therefore they shouldn't be used to validate user input or as an alternative to using exceptions.
 
 ### `assert`

--- a/gems/contract-programming.md
+++ b/gems/contract-programming.md
@@ -1,11 +1,10 @@
 # Contract programming
 
-Contract programming in D includes a set of language constructs
-that allow increasing the code quality by implementing
-sanity checks that make sure that the code base
-behaves as intended. Contracts are only available in
-**debug** mode and won't be run in release mode.
-Therefore they shouldn't be used to validate user input.
+Contract programming in D includes a set of language constructs that allow increasing the code quality 
+by implementing sanity checks that make sure that the code base behaves as intended. 
+Contracts are compiled and exectued when the software is build for testing or debugging. 
+In release builds (**-release** for DMD) they are completly skipped by the compiler,
+therefore they shouldn't be used to validate user input or as an alternative exception system.
 
 ### `assert`
 


### PR DESCRIPTION
I found the previous explanations a bit confusing, particularly the emphasize on **debug** that could lead to a confusion with the eponymous compiler switch. Also discourage to use asserts as an exception throwing system.