### PR TITLE
Update fibers.md

### DIFF
--- a/multithreading/fibers.md
+++ b/multithreading/fibers.md
@@ -95,6 +95,6 @@ void main()
     }
 
     // squareFiber could still be run because
-    // it has finished yet!
+    // it has not finished yet!
 }
 ```


### PR DESCRIPTION
missing the word 'not' in the sentence ' squareFiber could still be run because it has finished yet!'