### PR TITLE
Tell users how to navigate the tour

### DIFF
--- a/welcome/welcome-to-d.md
+++ b/welcome/welcome-to-d.md
@@ -39,6 +39,9 @@ Each section comes with a source code example that can be modified and used
 to experiment with D's language features.
 Click the run button (or `Ctrl-enter`) to compile and run it.
 
+To navigate this tour, either use the "`<` previous" and "next `>`" links at the
+bottom, or else go straight to particular sections using the menus at the top.
+
 ### Contributing
 
 This tour is [open source](https://github.com/dlang-tour)


### PR DESCRIPTION
It's not obvious how to navigate the tour. Upon first seeing it, I thought it was only one page, with the link at the bottom possibly providing that page in different languages. I think this one improvement will greatly increase the number of readers who make it past the first page.