### PR TITLE
need  to specify return type of overrided function

### DIFF
--- a/basics/interfaces.md
+++ b/basics/interfaces.md
@@ -14,7 +14,7 @@ Essentially `makeNoise` behaves like an `abstract` member
 function in a base class.
 
     class Dog : Animal {
-        override makeNoise() {
+        override void makeNoise() {
             ...
         }
     }


### PR DESCRIPTION
Otherwise won't compile with this error message.

    Error: function interface.Dog.makeNoise return type inference is not supported if may override base class function