### PR TITLE
Fix wrong syntax for struct initialization.

### DIFF
--- a/basics/structs.md
+++ b/basics/structs.md
@@ -29,7 +29,7 @@ can be explicitly accessed with `this`:
         }
             ...
 
-    Person p(30, 180); // initialization
+    Person p = Person(30, 180); // initialization
     p = Person(30, 180);  // assignment to new instance
 
 A `struct` might contain any number of member functions. These


### PR DESCRIPTION
`Person p(30, 180);` is C++ syntax, and is not accepted by dmd.