### PR TITLE
Only specify the minor version for all packages, s.t. they only need to be bumped for major releases

### DIFF
--- a/dub/emsi_containers.md
+++ b/dub/emsi_containers.md
@@ -6,7 +6,7 @@ Play with [emsi_containers](https://github.com/dlang-community/containers)
 
 ```d
 /+dub.sdl:
-dependency "emsi_containers" version="~>0.6.0"
+dependency "emsi_containers" version="~>0.6"
 +/
 import std.stdio;
 void main(string[] args)

--- a/dub/libdparse.md
+++ b/dub/libdparse.md
@@ -6,7 +6,7 @@ Play with [libdparse](https://github.com/dlang-community/libdparse)
 
 ```d
 /+dub.sdl:
-dependency "libdparse" version="~>0.7.2-alpha.5"
+dependency "libdparse" version="~>0.7"
 +/
 import dparse.ast;
 import std.stdio;

--- a/dub/mir-algorithm.md
+++ b/dub/mir-algorithm.md
@@ -6,7 +6,7 @@ Play with [mir-algorithm](http://docs.algorithm.dlang.io/latest/index.html).
 
 ```d
 /+dub.sdl:
-dependency "mir-algorithm" version="~>0.6.14"
+dependency "mir-algorithm" version="~>0.7"
 +/
 import std.stdio;
 void main(string[] args)

--- a/dub/mir.md
+++ b/dub/mir.md
@@ -6,7 +6,7 @@ Play with [mir](http://docs.mir.dlang.io/latest/index.html)
 
 ```d
 /+dub.sdl:
-dependency "mir" version="~>1.1.1"
+dependency "mir" version="~>1.1"
 +/
 import std.stdio;
 import mir.combinatorics;

--- a/dub/vibe-d.md
+++ b/dub/vibe-d.md
@@ -6,7 +6,7 @@ Play with [vibe.d](http://vibed.org).
 
 ```d
 /+ dub.sdl:
-dependency "vibe-d" version="~>0.8.2"
+dependency "vibe-d" version="~>0.8"
 +/
 import vibe.d;
 import std.stdio;


### PR DESCRIPTION
For now injecting the latest stable package into the Tour markdown is too much work.
However, a simple solution to avoid frequent updates is to use only the major and minor version.

> Restrict to a certain major version: "~>2.2", equivalent to ">=2.2.0 <3.0.0"

http://code.dlang.org/package-format?lang=sdl#version-specs