### PR TITLE
Use libatlas-base-dev instead of libblas and liblapack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ addons:
   apt:
     packages:
     - libevent-dev
-    - libblas-dev
-    - liblapack-dev
+    - libatlas-base-dev
 
 script:
   - echo "Check for trailing whitespace"

--- a/dub/lubeck.md
+++ b/dub/lubeck.md
@@ -21,7 +21,7 @@ backends are recommeded for Linux and Windows.
 /+dub.sdl:
 dependency "lubeck" version="~>0.0"
 dependency "mir-algorithm" version="~>0.7"
-libs "lapack" "blas"
+libs "lapack" "blas" "cblas"
 
 +/
 import std.stdio;


### PR DESCRIPTION
Let's see whether this works.
The advantage is that libatlas provides cblas out of the box.

CC @9il