### PR TITLE
Fix keyword in contract programming blocks (from `body` to `do`)

### DIFF
--- a/gems/contract-programming.md
+++ b/gems/contract-programming.md
@@ -28,7 +28,7 @@ parameters and return values of functions.
     } out (result) {
         assert((result * result) <= x
             && (result+1) * (result+1) > x);
-    } body {
+    } do {
         return cast(long)std.math.sqrt(cast(real)x);
     }
 


### PR DESCRIPTION
As [stated in documentation](https://dlang.org/spec/contracts.html#pre_post_contracts), contract programming keywords are `in`, `out` and `do`, not `body` (that is the old one).