### PR TITLE
Don't execute the lubeck test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
   apt:
     packages:
     - libevent-dev
-    - libblas-dev
-    - liblapack-dev
 
 script:
   - echo "Check for trailing whitespace"

--- a/dub/lubeck.md
+++ b/dub/lubeck.md
@@ -15,7 +15,7 @@ backends are recommeded for Linux and Windows.
  - [Mir Random API](http://docs.algorithm.dlang.io)
  - [Mir API](http://docs.mir.dlang.io)
 
-## {SourceCode}
+## {SourceCode:incomplete}
 
 ```d
 /+dub.sdl:


### PR DESCRIPTION
The lubeck file depends on a lot of system libraries (Laback + Blas), imho it's not worth the troubles of ensuring that it runs compared to the disadvantage of requiring everyone who wants to run the sanitycheck to have these libraries installed.