### PR TITLE
Don't check building of emsi_containers

### DIFF
--- a/dub/emsi_containers.md
+++ b/dub/emsi_containers.md
@@ -2,7 +2,7 @@
 
 Play with [emsi_containers](https://github.com/dlang-community/containers)
 
-## {SourceCode}
+## {SourceCode:incomplete}
 
 ```d
 /+dub.sdl:


### PR DESCRIPTION
There seems to be some DUB weirdness going one at the moment:

```
object.Exception@source/app.d(95): [en] Sanity check: Source code for section 'EMSI Containers' doesn't compile:
The determined compiler type "ldc" doesn't match the expected type "dmd". This will probably result in build errors.
gcc: error: ../../../.dub/packages/stdx-allocator-2.77.1/stdx-allocator/.dub/build/library-debug-linux.posix-x86_64-ldc_2078-E82A31223469E295FB18BBC0FC116AAE/libstdx-allocator.a: No such file or directory
Error: /usr/bin/gcc failed with status: 1
ldmd2 failed with exit code 1.
```

So disabling for now.