### PR TITLE
Set libdparse's example to incomplete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 language: d
 d:
   - dmd
-  - ldc
+  - ldc-1.7.0
 branches:
   only:
     - master

--- a/dub/libdparse.md
+++ b/dub/libdparse.md
@@ -2,7 +2,7 @@
 
 Play with [libdparse](https://github.com/dlang-community/libdparse)
 
-## {SourceCode:fullWidth}
+## {SourceCode:fullWidth:incomplete}
 
 ```d
 /+dub.sdl:


### PR DESCRIPTION
Seems to be reguarly failing with LDC, so better not test it for now to avoid unrelated CI errors.