### PR TITLE
welcome/languages: link to Vietnamese translation

### DIFF
--- a/welcome/languages.md
+++ b/welcome/languages.md
@@ -13,6 +13,7 @@ The Dlang Tour is available in multiple languages:
 - [Swedish - Svenska](https://tour.dlang.org/tour/sv/welcome/welcome-to-d) (partially, WIP)
 - [Turkish - Türkçe](https://tour.dlang.org/tour/tr/welcome/welcome-to-d) (partially, WIP)
 - [Ukrainian - Українська](https://tour.dlang.org/tour/uk/welcome/welcome-to-d)
+- [Vietnamese - Tiếng Việt](https://tour.dlang.org/tour/vi/welcome/welcome-to-d) ((partially, WIP)
 
 For English, just click on "Next" or use the right arrow key.
 

--- a/welcome/languages.md
+++ b/welcome/languages.md
@@ -13,7 +13,7 @@ The Dlang Tour is available in multiple languages:
 - [Swedish - Svenska](https://tour.dlang.org/tour/sv/welcome/welcome-to-d) (partially, WIP)
 - [Turkish - Türkçe](https://tour.dlang.org/tour/tr/welcome/welcome-to-d) (partially, WIP)
 - [Ukrainian - Українська](https://tour.dlang.org/tour/uk/welcome/welcome-to-d)
-- [Vietnamese - Tiếng Việt](https://tour.dlang.org/tour/vi/welcome/welcome-to-d) ((partially, WIP)
+- [Vietnamese - Tiếng Việt](https://tour.dlang.org/tour/vi/welcome/welcome-to-d) (partially, WIP)
 
 For English, just click on "Next" or use the right arrow key.
 


### PR DESCRIPTION
* Current progress: Translated Welcome and Basis sections

Thanks @wilzbach  for your reminder (https://github.com/dlang-tour/vietnamese/issues/12). It's my bad that I've just noticed that ticket :)