### PR TITLE
Update DUB package versions:

### DIFF
--- a/dub/emsi_containers.md
+++ b/dub/emsi_containers.md
@@ -6,7 +6,7 @@ Play with [emsi_containers](https://github.com/dlang-community/containers)
 
 ```d
 /+dub.sdl:
-dependency "emsi_containers" version="~>0.6"
+dependency "emsi_containers" version="~>0.7"
 +/
 import std.stdio;
 void main(string[] args)

--- a/dub/libdparse.md
+++ b/dub/libdparse.md
@@ -6,7 +6,7 @@ Play with [libdparse](https://github.com/dlang-community/libdparse)
 
 ```d
 /+dub.sdl:
-dependency "libdparse" version="~>0.7"
+dependency "libdparse" version="~>0.9"
 +/
 import dparse.ast;
 import std.stdio;

--- a/dub/pegged.md
+++ b/dub/pegged.md
@@ -15,7 +15,7 @@ to be used at runtime or compile time.
 
 ```d
 /+dub.sdl:
-dependency "pegged" version="~>0.4.2"
+dependency "pegged" version="~>0.4"
 +/
 import pegged.grammar;
 import std.stdio;


### PR DESCRIPTION
emsi_containers `~>0.6` -> `~>0.7`
libdparse `~>0.7` -> `~>0.9`
pegged `~>0.4.2` -> `~>0.4`