### PR TITLE
Fix mir version

### DIFF
--- a/dub/mir.md
+++ b/dub/mir.md
@@ -20,7 +20,7 @@ The package includes:
 
 ```d
 /+dub.sdl:
-dependency "mir" version="~>2.0"
+dependency "mir" version="~>3.0"
 +/
 import std.stdio;
 import mir.combinatorics;


### PR DESCRIPTION
The live example doesn't compile due to now unsupported version.