### PR TITLE
coedit is no longer available

### DIFF
--- a/welcome/install-d-locally.md
+++ b/welcome/install-d-locally.md
@@ -39,7 +39,6 @@ There are D plugins for at least the following editors:
 
 You may also want to try an IDE dedicated to D:
 
-- [Coedit](https://github.com/BBasile/Coedit)
 - [Dlang IDE](https://github.com/buggins/dlangide)
 
 The D wiki contains a more detailed overview of available [editors](https://wiki.dlang.org/Editors) and [IDEs](https://wiki.dlang.org/IDEs).


### PR DESCRIPTION
removed it from "Install D locally"

Could this list possibly be made some global so it's not necessary to maintain the list in all languages?