### PR TITLE
Grammatical Corrections

### DIFF
--- a/basics/alias-strings.md
+++ b/basics/alias-strings.md
@@ -35,7 +35,7 @@ units](http://unicode.org/glossary/#code_unit). All array operations can be
 used on strings, but they will work on a code unit level, and not a character level. At
 the same time, standard library algorithms will interpret `string`s as sequences
 of [code points](http://unicode.org/glossary/#code_point), and there is also an
-option to treat them as sequence of
+option to treat them as sequences of
 [graphemes](http://unicode.org/glossary/#grapheme) by explicit usage of
 [`std.uni.byGrapheme`](https://dlang.org/library/std/uni/by_grapheme.html).
 

--- a/basics/alias-strings.md
+++ b/basics/alias-strings.md
@@ -66,7 +66,7 @@ rely on standard library algorithms to do the right job.
 If by element (code unit) iteration is desired, one can use
 [`byCodeUnit`](http://dlang.org/phobos/std_utf.html#.byCodeUnit).
 
-Auto-decoding in D is explained in more details
+Auto-decoding in D is explained in more detail
 in the [Unicode gems chapter](gems/unicode).
 
 ### Multi-line strings

--- a/basics/associative-arrays.md
+++ b/basics/associative-arrays.md
@@ -24,7 +24,7 @@ and writes can be conveniently combined:
         *val = 20;
 
 Access to a key which doesn't exist yields a `RangeError`
-that immediately aborts the application. For a safe access
+that immediately aborts the application. For safe access
 with a default value, `get(key, defaultValue)` can be used.
 
 AA's have the `.length` property like arrays and provide

--- a/basics/delegates.md
+++ b/basics/delegates.md
@@ -64,7 +64,7 @@ to define a folding (aka reducer):
 
     [1, 2, 3].reduce!`a + b`; // 6
 
-String functions are only possible for _one or two_ arguments and then use `a`
+String functions are only possible for _one or two_ arguments and use `a`
 as first and `b` as second argument.
 
 ### In-depth

--- a/basics/delegates.md
+++ b/basics/delegates.md
@@ -65,7 +65,7 @@ to define a folding (aka reducer):
     [1, 2, 3].reduce!`a + b`; // 6
 
 String functions are only possible for _one or two_ arguments and use `a`
-as first and `b` as second argument.
+as the first and `b` as the second argument.
 
 ### In-depth
 

--- a/basics/ranges.md
+++ b/basics/ranges.md
@@ -70,7 +70,7 @@ r2.writeln; // []
 
 Most of the ranges in the standard library are structs and so `foreach`
 iteration is usually non-destructive, though not guaranteed. If this
-guarantee is important, an specialization of an `InputRange` can be used—
+guarantee is important, a specialization of an `InputRange` can be used—
 **forward** ranges with a `.save` method:
 
 ```

--- a/basics/ranges.md
+++ b/basics/ranges.md
@@ -127,9 +127,9 @@ r[1].writeln; // 5
 
 The functions in [`std.range`](http://dlang.org/phobos/std_range.html) and
 [`std.algorithm`](http://dlang.org/phobos/std_algorithm.html) provide
-building blocks that make use of this interface. Ranges allow
-to compose complex algorithms behind an object that
-can be iterated with ease. Furthermore, ranges allow to create **lazy**
+building blocks that make use of this interface. Ranges enable the
+composition of complex algorithms behind an object that
+can be iterated with ease. Furthermore, ranges enable the creation of **lazy**
 objects that only perform a calculation when it's really needed
 in an iteration e.g. when the next range's element is accessed.
 Special range algorithms will be presented later in the

--- a/welcome/run-d-program-locally.md
+++ b/welcome/run-d-program-locally.md
@@ -25,7 +25,7 @@ On UNIX systems the shebang line `#!/usr/bin/env rdmd` can be put
 on the first line of an executable D file to allow a script-like
 usage.
 
-Browse the [online documentation](https://dlang.org/rdmd.html) or run `rdmd --help` for for an overview of available flags.
+Browse the [online documentation](https://dlang.org/rdmd.html) or run `rdmd --help` for an overview of available flags.
 
 ### Package manager `dub`
 


### PR DESCRIPTION
Here are some grammatical corrections.

* Remove superfluous _for_. The word is duplicated.
* Pluralize _sequence_. It is incorrectly used here as an uncountable noun.
* Remove _s_ in _detail_. It is not idiomatic to say: "in more details".
* Change _an_ to _a_. "an sequence" is grammatically incorrect.
* Change _allow to_ without direct object. The phrase "allow to" is transitive and must be used with a direct object. e.g. He allowed me to enter. Not: He allowed to enter.
* Remove superfluous _a_. "a safe access" is not correct because _access_ is an uncountable noun.
* Remove unnecessary _then_. _then_ has no meaning in this context.
* Add _the_ before _first_ and _second_. The definite article _the_ should always be used before ordinal numbers.