### PR TITLE
Corrected lubeck package name and added selective imports for mir.ndslice

### DIFF
--- a/dub/lubeck.md
+++ b/dub/lubeck.md
@@ -23,7 +23,7 @@ dependency "lubeck" version="~>1.1"
 +/
 import kaleidic.lubeck: mtimes;
 import mir.algorithm.iteration: each;
-import mir.ndslice;
+import mir.ndslice: magic, repeat, as, slice, byDim;
 import std.stdio: writeln;
 
 void main()

--- a/dub/lubeck.md
+++ b/dub/lubeck.md
@@ -21,7 +21,7 @@ backends are recommeded for Linux and Windows.
 /+dub.sdl:
 dependency "lubeck" version="~>1.1"
 +/
-import lubeck: mtimes;
+import kaleidic.lubeck: mtimes;
 import mir.algorithm.iteration: each;
 import mir.ndslice;
 import std.stdio: writeln;


### PR DESCRIPTION
The Lubeck example was not working, I corrected the import statement.

I also added selective imports for mir.ndslice as the same is done for the other imports.