### PR TITLE
Update the source code to remove deprecation

### DIFF
--- a/multithreading/message-passing.md
+++ b/multithreading/message-passing.md
@@ -124,10 +124,10 @@ void main()
 
     // Odd threads get a number, even threads
     // a string!
-    foreach(int idx, ref tid; threads) {
+    foreach(idx, ref tid; threads) {
         import std.string : format;
         if (idx  % 2)
-            send(tid, NumberMessage(idx));
+            send(tid, NumberMessage(cast(int) idx));
         else
             send(tid, format("T=%d", idx));
     }


### PR DESCRIPTION
The following warning pops-up on compilation:
onlineapp.d(74): Deprecation: foreach: loop index implicitly converted from size_t to int

foreach has been updated to handle 2^31 or more elements, going past int max