### PR TITLE
alias this for classes has been deprecated

### DIFF
--- a/gems/subtyping.md
+++ b/gems/subtyping.md
@@ -23,8 +23,6 @@ in terms of memory or runtime. The compiler
 makes sure to do the right thing when
 accessing the `alias this` member.
 
-`alias this` work with classes too.
-
 ## {SourceCode}
 
 ```d


### PR DESCRIPTION
https://dlang.org/changelog/2.103.0.html#dmd.deprecate-alias-this-for-classes