### PR TITLE
Fix `delegates` anchor link

### DIFF
--- a/gems/functional-programming.md
+++ b/gems/functional-programming.md
@@ -4,7 +4,7 @@ D puts an emphasis on *functional programming* and provides
 first-class support for development
 in a functional style. See:
 * [immutable](basics/type-qualifiers) type qualifier
-* [anonymous functions](basics/delegates#anonymous-functions-lambdas)
+* [delegates](basics/delegates)
 * [range algorithms](gems/range-algorithms)
 
 ## Pure functions


### PR DESCRIPTION
Give up on linking to an anchor to fix buildkite (see also #367).

Note: This URL does go to the right place:
https://tour.dlang.org/tour/en/basics/delegates#anonymous-functions-lambdas

So I'm not sure why the anchor link didn't work. However, the address bar gets rewritten to:
https://tour.dlang.org/tour/en/basics/delegates#/anonymous-functions-lambdas

Which in turn doesn't work for the anchor.