### PR TITLE
opApply example isn't compliant with spec

### DIFF
--- a/gems/opdispatch-opapply.md
+++ b/gems/opdispatch-opapply.md
@@ -56,7 +56,7 @@ delegate as a parameter:
     }
     Tree tree = new Tree(5,
                          new Tree(3, new Tree(190)), new Tree(6));
-    foreach(node; tree) {
+    foreach (node; tree) {
         node.val.writeln;
     }
 

--- a/gems/opdispatch-opapply.md
+++ b/gems/opdispatch-opapply.md
@@ -55,9 +55,10 @@ delegate as a parameter:
             return 0;
         }
     }
-    Tree tree = new Tree;
+    Tree tree = new Tree(5,
+                         new Tree(3, new Tree(190)), new Tree(6));
     foreach(node; tree) {
-        ...
+        node.val.writeln;
     }
 
 The compiler transforms the `foreach` body to a special

--- a/gems/opdispatch-opapply.md
+++ b/gems/opdispatch-opapply.md
@@ -43,9 +43,9 @@ delegate as a parameter:
         Tree lhs;
         Tree rhs;
         int opApply(int delegate(Tree) dg) {
-            if (lhs && lhs.opApply(dg)) return 1;
-            if (dg(this)) return 1;
-            if (rhs && rhs.opApply(dg)) return 1;
+            if (int res = lhs ? lhs.opApply(dg) : 0) return res;
+            if (int res = rhs ? rhs.opApply(dg) : 0) return res;
+            if (int res = dg(this)) return res;
             return 0;
         }
     }

--- a/gems/opdispatch-opapply.md
+++ b/gems/opdispatch-opapply.md
@@ -48,7 +48,7 @@ delegate as a parameter:
             this.lhs = lhs;
             this.rhs = rhs;
         }
-        int opApply(int delegate(Tree) dg) {
+        int opApply(scope int delegate(ref Tree) dg) {
             if (int res = lhs ? lhs.opApply(dg) : 0) return res;
             if (int res = rhs ? rhs.opApply(dg) : 0) return res;
             return dg(this);

--- a/gems/opdispatch-opapply.md
+++ b/gems/opdispatch-opapply.md
@@ -51,8 +51,7 @@ delegate as a parameter:
         int opApply(int delegate(Tree) dg) {
             if (int res = lhs ? lhs.opApply(dg) : 0) return res;
             if (int res = rhs ? rhs.opApply(dg) : 0) return res;
-            if (int res = dg(this)) return res;
-            return 0;
+            return dg(this);
         }
     }
     Tree tree = new Tree(5,

--- a/gems/opdispatch-opapply.md
+++ b/gems/opdispatch-opapply.md
@@ -40,8 +40,14 @@ over such a type will call `opApply` with a special
 delegate as a parameter:
 
     class Tree {
+        int val;
         Tree lhs;
         Tree rhs;
+        this(int val, Tree lhs=null, Tree rhs=null){
+            this.val = val;
+            this.lhs = lhs;
+            this.rhs = rhs;
+        }
         int opApply(int delegate(Tree) dg) {
             if (int res = lhs ? lhs.opApply(dg) : 0) return res;
             if (int res = rhs ? rhs.opApply(dg) : 0) return res;

--- a/gems/opdispatch-opapply.md
+++ b/gems/opdispatch-opapply.md
@@ -43,7 +43,7 @@ delegate as a parameter:
         int val;
         Tree lhs;
         Tree rhs;
-        this(int val, Tree lhs=null, Tree rhs=null){
+        this(int val, Tree lhs = null, Tree rhs = null) {
             this.val = val;
             this.lhs = lhs;
             this.rhs = rhs;


### PR DESCRIPTION
c9bf6f2d761d5e0bf6e5f72053fde4aa5f009f1a  [The spec](https://dlang.org/spec/statement.html#foreach_over_struct_and_classes) states:
>If the result is nonzero, apply must cease iterating and return that value.

The other commit add some other small improvements to make the example copy-pastable with minimal friction.
