### PR TITLE
Incorrect function call in comment

### DIFF
--- a/multithreading/thread-local-storage.md
+++ b/multithreading/thread-local-storage.md
@@ -69,7 +69,7 @@ void worker(bool firstTime)
 void main()
 {
     // Create 5 threads that call
-    // worker(true,i) each.
+    // worker(true) each.
     for (size_t i = 0; i < 5; ++i) {
         spawn(&worker, true);
     }


### PR DESCRIPTION
This PR corrects a misleading comment. At first glance, I expected `i` to be printed by `worker`, but it is not passed in the actual thread call.